### PR TITLE
Set base.url so figures work properly

### DIFF
--- a/make.R
+++ b/make.R
@@ -12,7 +12,10 @@ knitr::opts_chunk$set(
 
 # Ensure knitr documents are knit with this directory
 # (not 'post/') as the root directory
-knitr::opts_knit$set(root.dir = getwd())
+knitr::opts_knit$set(
+  root.dir = getwd(),
+  base.url = "{{ site.baseurl }}/"
+  )
 
 # Insert zero-space UTF-8 characters, to avoid
 # a Jekyll bug that strips leading whitespace in output.


### PR DESCRIPTION
This sets the base.url for figures to be `{{ site.baseurl }}`, which will automatically resolve to the sites baseurl.  Seems to work well on the new incarnation of jimhester.com, i.e. (http://www.jimhester.com/blog/2013/03/11/ggplot-color-scales/)

Thanks again for letting me borrow your template, it was just what I was looking for.
